### PR TITLE
🐛 (redisq) preserve unread messages and retry pending entries

### DIFF
--- a/kratosz/kmw/ratemw/ratemw_test.go
+++ b/kratosz/kmw/ratemw/ratemw_test.go
@@ -23,6 +23,8 @@ var (
 	testOptsMaxCap = Options{Rate: 1, Burst: 1, StaleAfter: time.Hour, MaxEntries: 1}
 )
 
+type testContextKey struct{}
+
 func TestStore_Get(t *testing.T) {
 	t.Run("NewUser", func(t *testing.T) {
 		s := NewStore(testOptsBasic)
@@ -188,7 +190,8 @@ func TestMiddleware(t *testing.T) {
 			return "ok", nil
 		})
 
-		ctx, _ := context.WithDeadline(withClaims(1), time.Now().Add(-time.Second))
+		ctx, cancel := context.WithDeadline(withClaims(1), time.Now().Add(-time.Second))
+		defer cancel()
 
 		_, err := h(ctx, nil)
 		require.Error(t, err)
@@ -197,11 +200,11 @@ func TestMiddleware(t *testing.T) {
 }
 
 func withClaims(uid int64) context.Context {
-	return context.WithValue(context.Background(), "test_uid", uid)
+	return context.WithValue(context.Background(), testContextKey{}, uid)
 }
 
 func testExtractor(ctx context.Context) (string, bool) {
-	if uid, ok := ctx.Value("test_uid").(int64); ok && uid > 0 {
+	if uid, ok := ctx.Value(testContextKey{}).(int64); ok && uid > 0 {
 		return strconv.FormatInt(uid, 10), true
 	}
 	return "", false
@@ -219,8 +222,11 @@ func TestUtilities(t *testing.T) {
 	t.Run("MiddlewareHandlerType", func(t *testing.T) {
 		stores := NewStrategyStores(DefaultOptions())
 		t.Cleanup(stores.Close)
-		var _ middleware.Middleware = Middleware(stores, testExtractor)
-		var _ middleware.Middleware = WaitMiddleware(stores, testExtractor)
+		middlewares := []middleware.Middleware{
+			Middleware(stores, testExtractor),
+			WaitMiddleware(stores, testExtractor),
+		}
+		assert.Len(t, middlewares, 2)
 	})
 }
 

--- a/queue/redisq/README.md
+++ b/queue/redisq/README.md
@@ -4,6 +4,17 @@ Package `redisq` provides a Redis Stream based message queue.
 
 ## Max length of stream
 
+`MaxLen` is a retention target, not permission to delete unread messages.
+Before trimming, the consumer checks every group and keeps the earliest entry
+that is still pending or has not yet been delivered. A slow group can therefore
+keep the stream above `MaxLen`; the trim task emits stream length, pending, lag,
+safe-boundary, and trimmed-count fields so operators can see why.
+
+Pending entries are scanned continuously, including entries that fail after the
+consumer starts. After a pending batch, the consumer gives new entries a read
+opportunity so one repeatedly failing message cannot block the rest of the
+stream.
+
 The JSON object below is 360 characters long when serialized using `JSON.stringify()`.  
 Assume each message is 0.5 KB. For 100 streams, this amounts to approximately 50 KB.  
 With 10,000 messages per stream, the total size would be around 500 MB.

--- a/queue/redisq/redisq.go
+++ b/queue/redisq/redisq.go
@@ -582,60 +582,89 @@ func (c *Consumer) trimStreamWithStats(
 		return stats, fmt.Errorf("get consumer groups: %w", err)
 	}
 	stats.groups = len(groups)
+	addGroupStats(&stats, groups)
+
+	if length <= maxLen || len(groups) == 0 {
+		return stats, nil
+	}
+
+	stats.safeBeforeID, err = c.safeTrimBoundary(ctx, stream, groups)
+	if err != nil {
+		return stats, err
+	}
+	if stats.safeBeforeID == "" {
+		return stats, nil
+	}
+
+	stats.trimmed, err = c.client.XTrimMinID(ctx, stream, stats.safeBeforeID).Result()
+	if err != nil {
+		return stats, fmt.Errorf("trim before %q: %w", stats.safeBeforeID, err)
+	}
+	return stats, nil
+}
+
+func addGroupStats(stats *trimStats, groups []redis.XInfoGroup) {
 	for _, group := range groups {
 		stats.pending += group.Pending
 		if group.Lag >= 0 {
 			stats.lag += group.Lag
 		}
 	}
+}
 
-	if length <= maxLen || len(groups) == 0 {
-		return stats, nil
-	}
-
+func (c *Consumer) safeTrimBoundary(
+	ctx context.Context,
+	stream string,
+	groups []redis.XInfoGroup,
+) (string, error) {
+	var boundary string
 	for _, group := range groups {
-		safeBeforeID := group.LastDeliveredID
-		if group.Pending > 0 {
-			pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
-				Stream: stream,
-				Group:  group.Name,
-				Start:  "-",
-				End:    "+",
-				Count:  1,
-			}).Result()
-			if err != nil {
-				return stats, fmt.Errorf("get pending for group %q: %w", group.Name, err)
-			}
-			if len(pending) != 0 {
-				safeBeforeID = pending[0].ID
-			}
+		groupBoundary, err := c.groupTrimBoundary(ctx, stream, group)
+		if err != nil {
+			return "", err
 		}
-
-		if safeBeforeID == "" || safeBeforeID == "0-0" {
-			stats.safeBeforeID = safeBeforeID
-			return stats, nil
+		if groupBoundary == "" || groupBoundary == "0-0" {
+			return groupBoundary, nil
 		}
-		if stats.safeBeforeID == "" {
-			stats.safeBeforeID = safeBeforeID
+		if boundary == "" {
+			boundary = groupBoundary
 			continue
 		}
-		before, err := streamIDBefore(safeBeforeID, stats.safeBeforeID)
+
+		before, err := streamIDBefore(groupBoundary, boundary)
 		if err != nil {
-			return stats, err
+			return "", err
 		}
 		if before {
-			stats.safeBeforeID = safeBeforeID
+			boundary = groupBoundary
 		}
 	}
+	return boundary, nil
+}
 
-	if stats.safeBeforeID == "" {
-		return stats, nil
+func (c *Consumer) groupTrimBoundary(
+	ctx context.Context,
+	stream string,
+	group redis.XInfoGroup,
+) (string, error) {
+	if group.Pending == 0 {
+		return group.LastDeliveredID, nil
 	}
-	stats.trimmed, err = c.client.XTrimMinID(ctx, stream, stats.safeBeforeID).Result()
+
+	pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream: stream,
+		Group:  group.Name,
+		Start:  "-",
+		End:    "+",
+		Count:  1,
+	}).Result()
 	if err != nil {
-		return stats, fmt.Errorf("trim before %q: %w", stats.safeBeforeID, err)
+		return "", fmt.Errorf("get pending for group %q: %w", group.Name, err)
 	}
-	return stats, nil
+	if len(pending) == 0 {
+		return group.LastDeliveredID, nil
+	}
+	return pending[0].ID, nil
 }
 
 func streamIDBefore(a, b string) (bool, error) {

--- a/queue/redisq/redisq.go
+++ b/queue/redisq/redisq.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -218,6 +219,9 @@ type Route struct {
 	NoPending bool    // NoPending ignores the pending messages
 	BatchSize int64   // BatchSize specifies the number of messages fetched per batch
 	MaxLen    int64   // MaxLen specifies the max length of current stream
+
+	pendingStartID string
+	readNewNext    bool
 }
 
 // SpanName is the name of the span for tracing.
@@ -293,6 +297,7 @@ func (c *Consumer) MustAddRoute(r *Route) {
 	if r.PendingID == "" {
 		r.PendingID = "0"
 	}
+	r.pendingStartID = r.PendingID
 	if r.BatchSize == 0 {
 		r.BatchSize = 1
 	}
@@ -420,7 +425,6 @@ func (c *Consumer) readCheck(ctx context.Context, r *Route) (ms []RM, err error)
 
 func (c *Consumer) read(ctx context.Context, r *Route) (ms []RM, err error) {
 	var (
-		xss      []redis.XStream
 		xms      []redis.XMessage
 		consumer = "c1"
 	)
@@ -428,43 +432,63 @@ func (c *Consumer) read(ctx context.Context, r *Route) (ms []RM, err error) {
 	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	// After a pending batch, give new messages one non-blocking read before
+	// continuing the pending scan. This keeps a poison message from starving
+	// the rest of the stream.
+	if r.readNewNext {
+		r.readNewNext = false
+		xms, err = c.readGroup(readCtx, r, consumer, ">")
+		if err != nil && !errors.Is(err, redis.Nil) {
+			return nil, fmt.Errorf("read new: %w", err)
+		}
+		if len(xms) != 0 {
+			return collections.Map(xms, fromRedisMsg), nil
+		}
+	}
+
 	if !r.NoPending {
-		// Use any other ID (besides '>') to return all entries that are pending.
-		// See https://redis.io/commands/xreadgroup/.
-		xss, err = c.client.XReadGroup(readCtx, &redis.XReadGroupArgs{
-			Group:    r.Group,
-			Consumer: consumer,
-			Streams:  []string{r.Stream, r.PendingID},
-			Count:    r.BatchSize,
-		}).Result()
+		// Any ID other than ">" reads entries already pending for this
+		// consumer. Reaching the end resets the cursor so failures that
+		// happened after startup are revisited on the next scan.
+		xms, err = c.readGroup(readCtx, r, consumer, r.PendingID)
 		if err != nil {
 			return nil, fmt.Errorf("read pending: %w", err)
 		}
-		// If no pending entries, xss is "[{stream []}]".
-		// See TestXReadGroup for details.
-		xms = xss[0].Messages
-		r.NoPending = len(xms) < int(r.BatchSize)
-	}
-	if len(xms) != 0 {
-		// The last item has the biggest id.
-		r.PendingID = xms[len(xms)-1].ID
-	} else {
-		// If no data, err is "redis.Nil".
-		xss, err = c.client.XReadGroup(readCtx, &redis.XReadGroupArgs{
-			Group:    r.Group,
-			Consumer: consumer,
-			Streams:  []string{r.Stream, ">"},
-			Count:    r.BatchSize,
-			Block:    -1,
-		}).Result()
-		if err != nil {
-			return nil, fmt.Errorf("read new: %w", err)
+		if len(xms) != 0 {
+			r.PendingID = xms[len(xms)-1].ID
+			r.readNewNext = true
+			return collections.Map(xms, fromRedisMsg), nil
 		}
-		xms = xss[0].Messages
+		r.PendingID = r.pendingStartID
 	}
 
-	ms = collections.Map(xms, fromRedisMsg)
-	return
+	xms, err = c.readGroup(readCtx, r, consumer, ">")
+	if err != nil {
+		return nil, fmt.Errorf("read new: %w", err)
+	}
+	return collections.Map(xms, fromRedisMsg), nil
+}
+
+func (c *Consumer) readGroup(
+	ctx context.Context,
+	r *Route,
+	consumer string,
+	id string,
+) ([]redis.XMessage, error) {
+	xss, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    r.Group,
+		Consumer: consumer,
+		Streams:  []string{r.Stream, id},
+		Count:    r.BatchSize,
+		Block:    -1,
+	}).Result()
+	if err != nil {
+		return nil, err
+	}
+	if len(xss) == 0 {
+		return nil, nil
+	}
+	return xss[0].Messages, nil
 }
 
 // trim trims the streams to the max length.
@@ -475,36 +499,172 @@ func (c *Consumer) trim() {
 		return stream, lo.Max(lens)
 	})
 
-	var (
-		ctx      = c.ctx
-		interval = 3 * time.Minute
-		errCount = 0
-		l        = c.logger.With("task", "trim")
-	)
+	ctx := c.ctx
+	logger := c.logger.With("task", "trim")
+	run := func() {
+		trimCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
 
+		for stream, maxLen := range trims {
+			stats, err := c.trimStreamWithStats(trimCtx, stream, maxLen)
+			streamLogger := logger.With(
+				"stream", stream,
+				"length", stats.length,
+				"maxLen", maxLen,
+				"groups", stats.groups,
+				"pending", stats.pending,
+				"lag", stats.lag,
+				"safeBeforeID", stats.safeBeforeID,
+				"trimmed", stats.trimmed,
+			)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					streamLogger.ErrorContext(trimCtx, "trim error", "err", err)
+				}
+				continue
+			}
+			if stats.length > maxLen && stats.trimmed == 0 {
+				streamLogger.WarnContext(
+					trimCtx,
+					"stream above max length; preserving entries required by consumer groups",
+				)
+			} else {
+				streamLogger.DebugContext(trimCtx, "stream health checked")
+			}
+		}
+	}
+
+	run()
+	ticker := time.NewTicker(3 * time.Minute)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-			defer cancel()
-			for stream, maxLen := range trims {
-				l := l.With("stream", stream)
-				n, err := c.client.XTrimMaxLenApprox(ctx, stream, maxLen, 0).Result()
-				if err == nil {
-					errCount = 0
-					l.DebugContext(ctx, "xtrim done", "count", n)
-				} else {
-					if errors.Is(err, context.Canceled) {
-						return
-					}
-					errCount++
-					l.ErrorContext(ctx, "trim error", "errCount", errCount, "err", err)
-				}
-			}
-			time.Sleep(interval)
+		case <-ticker.C:
+			run()
+		}
+	}
+}
+
+type trimStats struct {
+	length       int64
+	groups       int
+	pending      int64
+	lag          int64
+	safeBeforeID string
+	trimmed      int64
+}
+
+func (c *Consumer) trimStream(ctx context.Context, stream string, maxLen int64) error {
+	_, err := c.trimStreamWithStats(ctx, stream, maxLen)
+	return err
+}
+
+func (c *Consumer) trimStreamWithStats(
+	ctx context.Context,
+	stream string,
+	maxLen int64,
+) (trimStats, error) {
+	var stats trimStats
+
+	length, err := c.client.XLen(ctx, stream).Result()
+	if err != nil {
+		return stats, fmt.Errorf("get stream length: %w", err)
+	}
+	stats.length = length
+	if length == 0 {
+		return stats, nil
+	}
+
+	groups, err := c.client.XInfoGroups(ctx, stream).Result()
+	if err != nil {
+		return stats, fmt.Errorf("get consumer groups: %w", err)
+	}
+	stats.groups = len(groups)
+	for _, group := range groups {
+		stats.pending += group.Pending
+		if group.Lag >= 0 {
+			stats.lag += group.Lag
 		}
 	}
 
+	if length <= maxLen || len(groups) == 0 {
+		return stats, nil
+	}
+
+	for _, group := range groups {
+		safeBeforeID := group.LastDeliveredID
+		if group.Pending > 0 {
+			pending, err := c.client.XPendingExt(ctx, &redis.XPendingExtArgs{
+				Stream: stream,
+				Group:  group.Name,
+				Start:  "-",
+				End:    "+",
+				Count:  1,
+			}).Result()
+			if err != nil {
+				return stats, fmt.Errorf("get pending for group %q: %w", group.Name, err)
+			}
+			if len(pending) != 0 {
+				safeBeforeID = pending[0].ID
+			}
+		}
+
+		if safeBeforeID == "" || safeBeforeID == "0-0" {
+			stats.safeBeforeID = safeBeforeID
+			return stats, nil
+		}
+		if stats.safeBeforeID == "" {
+			stats.safeBeforeID = safeBeforeID
+			continue
+		}
+		before, err := streamIDBefore(safeBeforeID, stats.safeBeforeID)
+		if err != nil {
+			return stats, err
+		}
+		if before {
+			stats.safeBeforeID = safeBeforeID
+		}
+	}
+
+	if stats.safeBeforeID == "" {
+		return stats, nil
+	}
+	stats.trimmed, err = c.client.XTrimMinID(ctx, stream, stats.safeBeforeID).Result()
+	if err != nil {
+		return stats, fmt.Errorf("trim before %q: %w", stats.safeBeforeID, err)
+	}
+	return stats, nil
+}
+
+func streamIDBefore(a, b string) (bool, error) {
+	aTime, aSequence, err := parseStreamID(a)
+	if err != nil {
+		return false, err
+	}
+	bTime, bSequence, err := parseStreamID(b)
+	if err != nil {
+		return false, err
+	}
+	if aTime != bTime {
+		return aTime < bTime, nil
+	}
+	return aSequence < bSequence, nil
+}
+
+func parseStreamID(id string) (uint64, uint64, error) {
+	timePart, sequencePart, ok := strings.Cut(id, "-")
+	if !ok {
+		return 0, 0, fmt.Errorf("invalid Redis stream ID %q", id)
+	}
+	timeValue, err := strconv.ParseUint(timePart, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse Redis stream ID %q time: %w", id, err)
+	}
+	sequenceValue, err := strconv.ParseUint(sequencePart, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse Redis stream ID %q sequence: %w", id, err)
+	}
+	return timeValue, sequenceValue, nil
 }

--- a/queue/redisq/redisq_test.go
+++ b/queue/redisq/redisq_test.go
@@ -2,6 +2,7 @@ package redisq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -230,6 +231,178 @@ func TestConsumer(t *testing.T) {
 		require.NoError(t, lenCmd.Err())
 		assert.Equal(t, int64(msgsCount), lenCmd.Val())
 	})
+}
+
+func TestHandleRouteRetriesNewlyPendingMessage(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		stream = testKeyPrefix + "retry-newly-pending"
+		group  = "retry-group"
+		rdb    = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	)
+	t.Cleanup(func() {
+		require.NoError(t, rdb.Del(ctx, stream).Err())
+		require.NoError(t, rdb.Close())
+	})
+
+	require.NoError(t, rdb.Del(ctx, stream).Err())
+	require.NoError(t, rdb.XGroupCreateMkStream(ctx, stream, group, "0").Err())
+	require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]any{"content": "retry me"},
+	}).Err())
+
+	attempts := 0
+	c := NewConsumer(rdb, slog.Default())
+	route := &Route{
+		Stream: stream,
+		Group:  group,
+		Handler: func(ctx Context) error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("temporary failure")
+			}
+			return nil
+		},
+	}
+	c.MustAddRoute(route)
+
+	require.Error(t, c.handleRoute(ctx, route))
+	require.NoError(t, c.handleRoute(ctx, route))
+	assert.Equal(t, 2, attempts)
+
+	pending, err := rdb.XPending(ctx, stream, group).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pending.Count)
+}
+
+func TestHandleRouteDoesNotLetPendingFailureBlockNewMessages(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		stream = testKeyPrefix + "pending-fairness"
+		group  = "fairness-group"
+		rdb    = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	)
+	t.Cleanup(func() {
+		require.NoError(t, rdb.Del(ctx, stream).Err())
+		require.NoError(t, rdb.Close())
+	})
+
+	require.NoError(t, rdb.Del(ctx, stream).Err())
+	require.NoError(t, rdb.XGroupCreateMkStream(ctx, stream, group, "0").Err())
+	firstID, err := rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]any{"content": "poison"},
+	}).Result()
+	require.NoError(t, err)
+	secondID, err := rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]any{"content": "healthy"},
+	}).Result()
+	require.NoError(t, err)
+
+	var handled []string
+	c := NewConsumer(rdb, slog.Default())
+	route := &Route{
+		Stream: stream,
+		Group:  group,
+		Handler: func(ctx Context) error {
+			id := ctx.Msg().ID
+			handled = append(handled, id)
+			if id == firstID {
+				return errors.New("poison message")
+			}
+			return nil
+		},
+	}
+	c.MustAddRoute(route)
+
+	require.Error(t, c.handleRoute(ctx, route))
+	require.Error(t, c.handleRoute(ctx, route))
+	require.NoError(t, c.handleRoute(ctx, route))
+	assert.Equal(t, []string{firstID, firstID, secondID}, handled)
+}
+
+func TestTrimStreamPreservesUnreadMessagesForSlowGroups(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		stream    = testKeyPrefix + "trim-slow-group"
+		fastGroup = "fast-group"
+		slowGroup = "slow-group"
+		rdb       = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	)
+	t.Cleanup(func() {
+		require.NoError(t, rdb.Del(ctx, stream).Err())
+		require.NoError(t, rdb.Close())
+	})
+
+	require.NoError(t, rdb.Del(ctx, stream).Err())
+	const messageCount = 200
+	for i := range messageCount {
+		require.NoError(t, rdb.XAdd(ctx, &redis.XAddArgs{
+			Stream: stream,
+			Values: map[string]any{"message": i},
+		}).Err())
+	}
+	require.NoError(t, rdb.XGroupCreate(ctx, stream, fastGroup, "0").Err())
+	require.NoError(t, rdb.XGroupCreate(ctx, stream, slowGroup, "0").Err())
+
+	fastMessages, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    fastGroup,
+		Consumer: "fast",
+		Streams:  []string{stream, ">"},
+		Count:    messageCount,
+		Block:    -1,
+	}).Result()
+	require.NoError(t, err)
+	fastIDs := lo.Map(fastMessages[0].Messages, func(message redis.XMessage, _ int) string {
+		return message.ID
+	})
+	require.NoError(t, rdb.XAck(ctx, stream, fastGroup, fastIDs...).Err())
+
+	const slowConsumed = 25
+	slowMessages, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    slowGroup,
+		Consumer: "slow",
+		Streams:  []string{stream, ">"},
+		Count:    slowConsumed,
+		Block:    -1,
+	}).Result()
+	require.NoError(t, err)
+	slowIDs := lo.Map(slowMessages[0].Messages, func(message redis.XMessage, _ int) string {
+		return message.ID
+	})
+	require.NoError(t, rdb.XAck(ctx, stream, slowGroup, slowIDs...).Err())
+
+	c := NewConsumer(rdb, slog.Default())
+	require.NoError(t, c.trimStream(ctx, stream, 10))
+
+	length, err := rdb.XLen(ctx, stream).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(messageCount-slowConsumed+1), length)
+
+	unread, err := rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    slowGroup,
+		Consumer: "slow",
+		Streams:  []string{stream, ">"},
+		Count:    messageCount,
+		Block:    -1,
+	}).Result()
+	require.NoError(t, err)
+	assert.Len(t, unread[0].Messages, messageCount-slowConsumed)
+}
+
+func TestStreamIDBeforeUsesNumericOrdering(t *testing.T) {
+	before, err := streamIDBefore("9-10", "10-1")
+	require.NoError(t, err)
+	assert.True(t, before)
+
+	before, err = streamIDBefore("10-2", "10-1")
+	require.NoError(t, err)
+	assert.False(t, before)
+
+	_, err = streamIDBefore("invalid", "10-1")
+	require.Error(t, err)
 }
 
 func consume(t *testing.T, ctx context.Context, c *Consumer, wait time.Duration) {


### PR DESCRIPTION
- continuously retry Redis Stream pending messages
- prevent poison messages from blocking new messages
- preserve entries still required by any consumer group during trimming
- add stream lag, pending, safe-boundary, and trim-count logs
- add regression tests for retry fairness and group-safe trimming